### PR TITLE
DU with values

### DIFF
--- a/Benchmarks.fs
+++ b/Benchmarks.fs
@@ -42,6 +42,14 @@ type Benchmarks () =
         acc
 
     [<Benchmark>]
+    member _.DUWithValues () =
+        let mutable acc = 0.0f
+        for shape in DUWithValues.shapes do
+            acc <- acc + (DUWithValues.Shape.area shape / (1.0f + DUWithValues.Shape.cornerCount shape))
+
+        acc
+
+    [<Benchmark>]
     member _.AltDULoop () =
 
         let circleCoef = Constants.pi / (1.0f + DU.Circle.cornerCount)

--- a/CleanCode.fsproj
+++ b/CleanCode.fsproj
@@ -14,6 +14,7 @@
         <Compile Include="StructDU.fs"/>
         <Compile Include="CompactDU.fs"/>
         <Compile Include="SeparateShapes.fs"/>
+        <Compile Include="DUWithValues.fs"/>
         <Compile Include="Benchmarks.fs"/>
         <Compile Include="Program.fs"/>
     </ItemGroup>

--- a/DUWithValues.fs
+++ b/DUWithValues.fs
@@ -1,0 +1,36 @@
+module CleanCode.DUWithValues
+
+type Shape =
+| Circle of radius : float32
+| Square of side : float32
+| Rectangle of length : float32 * width : float32
+| Triangle of length : float32 * width : float32
+
+module Shape =
+    let area = function
+        | Circle r -> r * r * Constants.pi
+        | Square s -> s * s
+        | Rectangle (l, w) -> l * w
+        | Triangle (l, w) -> l * w * 0.5f
+
+    let cornerCount = function
+        | Circle _ -> 0.0f
+        | Square _ -> 4.0f
+        | Rectangle _ -> 4.0f
+        | Triangle _ -> 3.0f
+
+let shapes =
+    [|
+        for shape in Inheritance.shapes do
+            match shape with
+            | :? Inheritance.Circle as c ->
+                Circle c.Radius
+            | :? Inheritance.Square as s ->
+                Square s.Length
+            | :? Inheritance.Rectangle as r ->
+                Rectangle (r.Width, r.Height)
+            | :? Inheritance.Triangle as t ->
+                Triangle (t.Width, t.Height)
+            | _ ->
+                failwith "Unknown subtype"
+    |]


### PR DESCRIPTION
I think this is a natural way to try to encode the problem in F# - or at least, this is how I would write it. The value of adding this sort of depends on how much the example is an abstraction of a real-world problem vs. how much we're analyzing the actual code we have. There's lots of times I've written a DU in this style (that is, of a tuple, not of an object) so having it as a reference may help.

Now that I've done all the work and typed it all out, I realize that a DU of a tuple vs. the DU of a record really aren't going to be that different in performance, which matches the results I got.

These are the results with **100** shapes, because I'm impatient, but it got more or less the result I expected. I don't have the cycles because Ubuntu is giving me some error on that and I didn't want to dive into that rabbit hole.

|           Method |      Mean |    Error |   StdDev | Ratio | RatioSD | Code Size |
|----------------- |----------:|---------:|---------:|------:|--------:|----------:|
|      Inheritance | 522.81 ns | 1.583 ns | 1.403 ns |  8.23 |    0.03 |     147 B |
|        Interface | 869.45 ns | 1.390 ns | 1.301 ns | 13.69 |    0.03 |     157 B |
|               DU | 758.99 ns | 1.410 ns | 1.250 ns | 11.95 |    0.03 |     433 B |
|     DUWithValues | 723.91 ns | 1.928 ns | 1.709 ns | 11.40 |    0.03 |     417 B |
|        AltDULoop | 262.08 ns | 1.204 ns | 1.068 ns |  4.13 |    0.02 |     432 B |
|         StructDU | 237.60 ns | 0.398 ns | 0.353 ns |  3.74 |    0.01 |     470 B |
|        CompactDU | 169.08 ns | 0.375 ns | 0.332 ns |  2.66 |    0.01 |     265 B |
| AltCompactDULoop | 102.18 ns | 0.295 ns | 0.230 ns |  1.61 |    0.00 |     176 B |
|   SeparateShapes |  63.53 ns | 0.147 ns | 0.123 ns |  1.00 |    0.00 |     264 B |

Anyways, hopefully this was interesting, feel free to merge it or close it - this is mostly for sharing and my own education.